### PR TITLE
fix typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # bs-svg-attachment
 
-Tiny utility functions for SVG DOM mainly in Buckle Script / Reason.
+Tiny utility functions for SVG DOM mainly in BuckleScript / Reason.
 
 ## Features
 
 - Simple, easy.
 - No dirty DOM. No append some extra attributes.
 
-## Installaion
+## Installation
 
-SVG attachment depents on types of `bs-webapi`.
+SVG attachment depends on types of `bs-webapi`.
 
 ```bash
 npm install bs-svg-attachment bs-webapi


### PR DESCRIPTION
I'm also pretty sure you don't need to explicitly install bs-webapi, since you have it as a dependency in pakcage.json.